### PR TITLE
AC ≠ Auto Conditioning

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -584,8 +584,8 @@ Set the temperature target for the HVAC system.
               }
             }
 
-## Start Air Condition [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_start]
-Start the HVAC system. Will cool or heat automatically, depending on set temperature.
+## Start Auto Conditioning [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_start]
+Start the climate control system. Will cool or heat automatically, depending on set temperature.
 
 + Request
     + Headers
@@ -607,8 +607,8 @@ Start the HVAC system. Will cool or heat automatically, depending on set tempera
               }
             }
 
-## Stop Air Condition [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_stop]
-Stop the HVAC system.
+## Stop Auto Conditioning [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_stop]
+Stop the climate control system.
 
 + Request
     + Headers


### PR DESCRIPTION
Starting auto conditioning just turns on climate control. It may or may not use AC, depending on your settings.