### PR TITLE
Fixes a syntax error in vehicle.rb with ruby 1.9.3

### DIFF
--- a/lib/tesla_api/vehicle.rb
+++ b/lib/tesla_api/vehicle.rb
@@ -142,7 +142,7 @@ module TeslaApi
       api.get("/vehicles/#{id}/data_request/#{name}")
     end
 
-    def command(name, body: nil)
+    def command(name, body = nil)
       api.post("/vehicles/#{id}/command/#{name}", body: body)
     end
   end


### PR DESCRIPTION
Fixes a syntax error in the command definition of `vehicle.rb` that I got with `ruby 1.9.3p484 (2013-11-22 revision 43786) [i686-linux]`.

This was the error:
```
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': /var/lib/gems/1.9.1/gems/tesla_api-1.2.0/lib/tesla_api/vehicle.rb:145: syntax error, unexpected tLABEL (SyntaxError)
    def command(name, body: nil)
                           ^
/var/lib/gems/1.9.1/gems/tesla_api-1.2.0/lib/tesla_api/vehicle.rb:149: syntax error, unexpected keyword_end, expecting $end
```