### PR TITLE
Autopark support in gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,33 @@ end
 
 desc "Open an irb session preloaded with this library"
 task :console do
-  sh "irb -rubygems -I lib -r tesla_api.rb -rdotenv"
+  # Load all gems
+  require 'rubygems'
+  require 'bundler/setup'
+  Bundler.require(:default)
+
+  # Load the envs
+  require 'dotenv'
+  Dotenv.load!
+
+  # Set up a global client
+  def client
+    @client ||= begin
+        client = TeslaApi::Client.new(ENV['TESLA_EMAIL'])
+        client.login!(ENV['TESLA_PASS'])
+        client
+    end
+  end
+
+  # Load IRB
+  require 'irb'
+  require 'irb/completion'
+
+  IRB.conf[:PROMPT_MODE] = :SIMPLE
+  IRB.conf[:AUTO_INDENT] = true
+
+  ARGV.clear
+  IRB.start
 end
 
 task default: :spec

--- a/lib/tesla_api.rb
+++ b/lib/tesla_api.rb
@@ -1,7 +1,8 @@
-require "httparty"
-require "em-http-request"
+require 'httparty'
+require 'em-http-request'
 
-require "tesla_api/version"
-require "tesla_api/client"
-require "tesla_api/stream"
-require "tesla_api/vehicle"
+require 'tesla_api/version'
+require 'tesla_api/client'
+require 'tesla_api/stream'
+require 'tesla_api/autopark'
+require 'tesla_api/vehicle'

--- a/lib/tesla_api/autopark.rb
+++ b/lib/tesla_api/autopark.rb
@@ -1,0 +1,62 @@
+require 'faye/websocket'
+
+module TeslaApi
+  module Autopark
+    def start_autopark(&handler)
+      EventMachine.run do
+        socket.on(:message) do |event|
+          message = if event.data.is_a?(Array)
+            JSON.parse(event.data.map(&:chr).join)
+          else
+            JSON.parse(event.data)
+          end
+
+          default_handler(message)
+          handler.call(message.delete('msg_type'), message)
+        end
+
+        socket.on(:close) do |_|
+          @socket = nil
+          @heartbeat && @heartbeat.cancel
+          EventMachine.stop
+        end
+      end
+    end
+
+    private
+
+    def default_handler(message)
+      case message['msg_type']
+        when 'control:hello'
+          interval = message['autopark']['heartbeat_frequency'] / 1000.0
+          @heartbeat = EventMachine::Timer.new(interval) do
+            beat = {
+                msg_type: 'autopark:heartbeat_app',
+                timestamp: Time.now.to_i
+            }
+            socket.send(beat.to_json)
+          end
+      end
+    end
+
+    def socket
+      @socket ||= Faye::WebSocket::Client.new(
+          socket_endpoint,
+          nil,
+          {
+              headers: {
+                  'Authorization' => "Basic #{socket_auth}"
+              }
+          }
+      )
+    end
+
+    def socket_auth
+      Base64.strict_encode64("#{email}:#{self['tokens'].first}")
+    end
+
+    def socket_endpoint
+      "wss://streaming.vn.teslamotors.com/connect/#{self['vehicle_id']}"
+    end
+  end
+end

--- a/lib/tesla_api/vehicle.rb
+++ b/lib/tesla_api/vehicle.rb
@@ -1,6 +1,7 @@
 module TeslaApi
   class Vehicle
     include Stream
+    include Autopark
     attr_reader :api, :email, :id, :vehicle
 
     def initialize(api, email, id, vehicle)

--- a/lib/tesla_api/version.rb
+++ b/lib/tesla_api/version.rb
@@ -1,3 +1,3 @@
 module TeslaApi
-  VERSION = "1.2.0"
+  VERSION = '1.3.0'
 end

--- a/tesla_api.gemspec
+++ b/tesla_api.gemspec
@@ -1,32 +1,30 @@
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'tesla_api/version'
+require File.expand_path('../lib/tesla_api/version', __FILE__)
 
 Gem::Specification.new do |spec|
-  spec.name          = "tesla_api"
+  spec.name          = 'tesla_api'
   spec.version       = TeslaApi::VERSION
-  spec.authors       = ["Tim Dorr"]
-  spec.email         = ["timdorr@timdorr.com"]
+  spec.authors       = ['Tim Dorr']
+  spec.email         = ['timdorr@timdorr.com']
   spec.summary       = %q{A wrapper for the Tesla API}
   spec.description   = %q{Check the state of your Tesla Model S and issue basic commands. Stream data from the car's telematics system.}
-  spec.homepage      = "https://github.com/timdorr/model-s-api"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/timdorr/model-s-api'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\0")
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "httparty"
-  spec.add_dependency "em-http-request"
+  spec.add_dependency 'httparty'
+  spec.add_dependency 'faye-websocket'
+  spec.add_dependency 'em-http-request'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "faker", "~> 1.4"
-  spec.add_development_dependency "vcr", "~> 2.9"
-  spec.add_development_dependency "webmock", "~> 1.20"
-  spec.add_development_dependency "dotenv", "~> 1.0"
-  spec.add_development_dependency "simplecov", "~> 0.9"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.1'
+  spec.add_development_dependency 'faker', '~> 1.4'
+  spec.add_development_dependency 'vcr', '~> 2.9'
+  spec.add_development_dependency 'webmock', '~> 1.20'
+  spec.add_development_dependency 'dotenv', '~> 1.0'
+  spec.add_development_dependency 'simplecov', '~> 0.9'
+  spec.add_development_dependency 'coveralls'
 end


### PR DESCRIPTION
Adds a `start_autopark` method on `TeslaApi::Vehicle`. Takes in a block that gets two args: `msg_type` and `message`.

Here's some really basic code that gets things started:
```ruby
vehicle = client.vehicles.first
vehicle.start_autopark do |msg_type, message| 
  p msg_type, message 
end
```