### PR TITLE
Disambiguated id vs vehicle_id and added documentation for option_codes

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -58,7 +58,7 @@ Retrieve a list of your owned vehicles (includes vehicles not yet shipped!)
                 "id": 321,
                 "option_codes": "MS01,RENA,TM00,DRLH,PF00,BT85,PBCW,RFPO,WT19,IBMB,IDPB,TR00,SU01,SC01,TP01,AU01,CH00,HP00,PA00,PS00,AD02,X020,X025,X001,X003,X007,X011,X013",
                 "user_id": 123,
-                "vehicle_id": 1234567890,
+                "id": 1234567890,
                 "vin": "5YJSA1CN5CFP01657",
                 "tokens": ["x", "x"],
                 "state": "online"
@@ -67,14 +67,14 @@ Retrieve a list of your owned vehicles (includes vehicles not yet shipped!)
             }
 
 
-## State and Settings [/api/1/vehicles/{vehicle_id}]
+## State and Settings [/api/1/vehicles/{id}]
 These resources are read-only and determine the state of the vehicle's various sub-systems.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
-## Mobile Access [GET /api/1/vehicles/{vehicle_id}/mobile_enabled]
+## Mobile Access [GET /api/1/vehicles/{id}/mobile_enabled]
 Determines if mobile access to the vehicle is enabled.
 
 + Request
@@ -84,7 +84,7 @@ Determines if mobile access to the vehicle is enabled.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -94,7 +94,7 @@ Determines if mobile access to the vehicle is enabled.
                 "response": true
             }
 
-## Charge State [GET /api/1/vehicles/{vehicle_id}/data_request/charge_state]
+## Charge State [GET /api/1/vehicles/{id}/data_request/charge_state]
 Returns the state of charge in the battery.
 
 + Request
@@ -104,7 +104,7 @@ Returns the state of charge in the battery.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -133,7 +133,7 @@ Returns the state of charge in the battery.
               }
             }
 
-## Climate Settings [GET /api/1/vehicles/{vehicle_id}/data_request/climate_state]
+## Climate Settings [GET /api/1/vehicles/{id}/data_request/climate_state]
 Returns the current temperature and climate control state.
 
 + Request
@@ -143,7 +143,7 @@ Returns the current temperature and climate control state.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -162,7 +162,7 @@ Returns the current temperature and climate control state.
               }
             }
 
-## Driving and Position [GET /api/1/vehicles/{vehicle_id}/data_request/drive_state]
+## Driving and Position [GET /api/1/vehicles/{id}/data_request/drive_state]
 Returns the driving and position state of the vehicle.
 
 + Request
@@ -172,7 +172,7 @@ Returns the driving and position state of the vehicle.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -189,7 +189,7 @@ Returns the driving and position state of the vehicle.
               }
             }
 
-## GUI Settings [GET /api/1/vehicles/{vehicle_id}/data_request/gui_settings]
+## GUI Settings [GET /api/1/vehicles/{id}/data_request/gui_settings]
 Returns various information about the GUI settings of the car, such as unit format and range display.
 
 + Request
@@ -199,7 +199,7 @@ Returns various information about the GUI settings of the car, such as unit form
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -215,7 +215,7 @@ Returns various information about the GUI settings of the car, such as unit form
               }
             }
 
-## Vehicle State [GET /api/1/vehicles/{vehicle_id}/data_request/vehicle_state]
+## Vehicle State [GET /api/1/vehicles/{id}/data_request/vehicle_state]
 Returns the vehicle's physical state, such as which doors are open.
 
 + Request
@@ -225,7 +225,7 @@ Returns the vehicle's physical state, such as which doors are open.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -255,7 +255,7 @@ Returns the vehicle's physical state, such as which doors are open.
 # Group Vehicle Commands
 These commands alter the vehicles state, and return result (true/false) to indicate success, and if failure reason contains the cause of failure.
 
-## Wake Up Car [POST /api/1/vehicles/{vehicle_id}/wake_up]
+## Wake Up Car [POST /api/1/vehicles/{id}/wake_up]
 Wakes up the car from the sleep state. Necessary to get some data from the car.
 
 + Request
@@ -265,7 +265,7 @@ Wakes up the car from the sleep state. Necessary to get some data from the car.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -278,7 +278,7 @@ Wakes up the car from the sleep state. Necessary to get some data from the car.
               }
             }
 
-## Set Valet Mode [POST /api/1/vehicles/{vehicle_id}/command/set_valet_mode]
+## Set Valet Mode [POST /api/1/vehicles/{id}/command/set_valet_mode]
 Sets valet mode on or off with a PIN to disable it from within the car. Reuses last PIN from previous valet session.
 Valet Mode limits the car's top speed to 70MPH and 80kW of acceleration power. It also disables Homelink, Bluetooth and
 Wifi settings, and the ability to disable mobile access to the car. It also hides your favorites, home, and work
@@ -291,7 +291,7 @@ locations in navigation.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + on: true (boolean) - Whether to enable or disable valet mode.
     + password: 1234 (number) - (optional) A 4 digit PIN code to unlock the car.
 
@@ -306,7 +306,7 @@ locations in navigation.
               }
             }
 
-## Reset Valet PIN [POST /api/1/vehicles/{vehicle_id}/command/reset_valet_pin]
+## Reset Valet PIN [POST /api/1/vehicles/{id}/command/reset_valet_pin]
 Resets the PIN set for valet mode, if set.
 
 + Request
@@ -316,7 +316,7 @@ Resets the PIN set for valet mode, if set.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -329,7 +329,7 @@ Resets the PIN set for valet mode, if set.
               }
             }
 
-## Open Charge Port [POST /api/1/vehicles/{vehicle_id}/command/charge_port_door_open]
+## Open Charge Port [POST /api/1/vehicles/{id}/command/charge_port_door_open]
 Opens the charge port. Does not close the charge port (for now...)
 
 + Request
@@ -339,7 +339,7 @@ Opens the charge port. Does not close the charge port (for now...)
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -352,7 +352,7 @@ Opens the charge port. Does not close the charge port (for now...)
               }
             }
 
-## Set Charge Limit to Standard [POST /api/1/vehicles/{vehicle_id}/command/charge_standard]
+## Set Charge Limit to Standard [POST /api/1/vehicles/{id}/command/charge_standard]
 Set the charge mode to standard (90% under the new percentage system introduced in 4.5).
 
 + Request
@@ -362,7 +362,7 @@ Set the charge mode to standard (90% under the new percentage system introduced 
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -375,7 +375,7 @@ Set the charge mode to standard (90% under the new percentage system introduced 
               }
             }
 
-## Set Charge Limit to Max Range [POST /api/1/vehicles/{vehicle_id}/command/charge_max_range]
+## Set Charge Limit to Max Range [POST /api/1/vehicles/{id}/command/charge_max_range]
 Set the charge mode to max range (100% under the new percentage system introduced in 4.5). Use sparingly!
 
 + Request
@@ -385,7 +385,7 @@ Set the charge mode to max range (100% under the new percentage system introduce
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -398,7 +398,7 @@ Set the charge mode to max range (100% under the new percentage system introduce
               }
             }
 
-## Set Charge Limit [POST /api/1/vehicles/{vehicle_id}/command/set_charge_limit?percent={limit_value}]
+## Set Charge Limit [POST /api/1/vehicles/{id}/command/set_charge_limit?percent={limit_value}]
 Set the charge limit to a custom percentage.
 
 + Request
@@ -408,7 +408,7 @@ Set the charge limit to a custom percentage.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + limit_value: `75` (number) - The percentage value
 
 + Response 200 (application/json)
@@ -422,7 +422,7 @@ Set the charge limit to a custom percentage.
               }
             }
 
-## Start Charging [POST /api/1/vehicles/{vehicle_id}/command/charge_start]
+## Start Charging [POST /api/1/vehicles/{id}/command/charge_start]
 Start charging. Must be plugged in, have power available, and not have reached your charge limit.
 
 + Request
@@ -432,7 +432,7 @@ Start charging. Must be plugged in, have power available, and not have reached y
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -445,7 +445,7 @@ Start charging. Must be plugged in, have power available, and not have reached y
               }
             }
 
-## Stop Charging [POST /api/1/vehicles/{vehicle_id}/command/charge_stop]
+## Stop Charging [POST /api/1/vehicles/{id}/command/charge_stop]
 Stop charging. Must already be charging.
 
 + Request
@@ -455,7 +455,7 @@ Stop charging. Must already be charging.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -468,7 +468,7 @@ Stop charging. Must already be charging.
               }
             }
 
-## Flash Lights [POST /api/1/vehicles/{vehicle_id}/command/flash_lights]
+## Flash Lights [POST /api/1/vehicles/{id}/command/flash_lights]
 Flash the lights once.
 
 + Request
@@ -478,7 +478,7 @@ Flash the lights once.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -491,7 +491,7 @@ Flash the lights once.
               }
             }
 
-## Honk Horn [POST /api/1/vehicles/{vehicle_id}/command/honk_horn]
+## Honk Horn [POST /api/1/vehicles/{id}/command/honk_horn]
 Honk the horn once.
 
 + Request
@@ -501,7 +501,7 @@ Honk the horn once.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -514,7 +514,7 @@ Honk the horn once.
               }
             }
 
-## Unlock Doors [POST /api/1/vehicles/{vehicle_id}/command/door_unlock]
+## Unlock Doors [POST /api/1/vehicles/{id}/command/door_unlock]
 Unlock the car's doors.
 
 + Request
@@ -524,7 +524,7 @@ Unlock the car's doors.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -537,7 +537,7 @@ Unlock the car's doors.
               }
             }
 
-## Lock Doors [POST /api/1/vehicles/{vehicle_id}/command/door_lock]
+## Lock Doors [POST /api/1/vehicles/{id}/command/door_lock]
 Lock the car's doors.
 
 + Request
@@ -547,7 +547,7 @@ Lock the car's doors.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -560,7 +560,7 @@ Lock the car's doors.
               }
             }
 
-## Set Temperature [POST /api/1/vehicles/{vehicle_id}/command/set_temps?driver_temp={driver_degC}&passenger_temp={pass_degC}]
+## Set Temperature [POST /api/1/vehicles/{id}/command/set_temps?driver_temp={driver_degC}&passenger_temp={pass_degC}]
 Set the temperature target for the HVAC system.
 
 + Request
@@ -570,7 +570,7 @@ Set the temperature target for the HVAC system.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + driver_degC: `23.7` (number) - The desired temperature on the driver's side in celcius.
     + pass_degC: `18.1` (number) - The desired temperature on the passenger's side in celcius.
 
@@ -585,7 +585,7 @@ Set the temperature target for the HVAC system.
               }
             }
 
-## Start HVAC System [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_start]
+## Start HVAC System [POST /api/1/vehicles/{id}/command/auto_conditioning_start]
 Start the climate control system. Will cool or heat automatically, depending on set temperature.
 
 + Request
@@ -595,7 +595,7 @@ Start the climate control system. Will cool or heat automatically, depending on 
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -608,7 +608,7 @@ Start the climate control system. Will cool or heat automatically, depending on 
               }
             }
 
-## Stop HVAC System  [POST /api/1/vehicles/{vehicle_id}/command/auto_conditioning_stop]
+## Stop HVAC System  [POST /api/1/vehicles/{id}/command/auto_conditioning_stop]
 Stop the climate control system.
 
 + Request
@@ -618,7 +618,7 @@ Stop the climate control system.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
 
 + Response 200 (application/json)
 
@@ -631,7 +631,7 @@ Stop the climate control system.
               }
             }
 
-## Move Pano Roof [POST /api/1/vehicles/{vehicle_id}/command/sun_roof_control?state={state}&percent={percent}]
+## Move Pano Roof [POST /api/1/vehicles/{id}/command/sun_roof_control?state={state}&percent={percent}]
 Controls the car's panoramic roof, if installed.
 
 + Request
@@ -641,7 +641,7 @@ Controls the car's panoramic roof, if installed.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + state: `open` (enum[string])
         The desired state of the panoramic roof. The approximate percent open values for each state are `open` = 100%, `close` = 0%, `comfort` = 80%, and `vent` = ~15%
         + Members
@@ -663,7 +663,7 @@ Controls the car's panoramic roof, if installed.
               }
             }
 
-## Remote Start [POST /api/1/vehicles/{vehicle_id}/command/remote_start_drive?password={password}]
+## Remote Start [POST /api/1/vehicles/{id}/command/remote_start_drive?password={password}]
 Start the car for keyless driving. Must start driving within 2 minutes of issuing this request.
 
 + Request
@@ -673,7 +673,7 @@ Start the car for keyless driving. Must start driving within 2 minutes of issuin
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + password: `edisonsux` (string) - The password to the authenticated my.teslamotors.com account.
 
 + Response 200 (application/json)
@@ -687,7 +687,7 @@ Start the car for keyless driving. Must start driving within 2 minutes of issuin
               }
             }
 
-## Open Trunk/Frunk [POST /api/1/vehicles/{vehicle_id}/command/trunk_open]
+## Open Trunk/Frunk [POST /api/1/vehicles/{id}/command/trunk_open]
 Open the trunk or frunk. Currently inoperable.
 
 + Request
@@ -697,7 +697,7 @@ Open the trunk or frunk. Currently inoperable.
 
 + Parameters
 
-    + vehicle_id: `1` (number) - The id of the Vehicle.
+    + id: `1` (number) - The id of the Vehicle.
     + which_trunk: `rear` (string) - The trunk to open. `rear` is the only one known currently.
 
 + Response 200 (application/json)

--- a/apiary.apib
+++ b/apiary.apib
@@ -40,7 +40,7 @@ A logged in user can have multiple vehicles under their account. This resource i
 ## Vehicle Collection [/api/1/vehicles]
 
 ### List all Vehicles [GET]
-Retrieve a list of your owned vehicles (includes vehicles not yet shipped!)
+Retrieve a list of your owned vehicles (includes vehicles not yet shipped!). The option_codes are documented at [https://github.com/benhannel/model-s-api/blob/master/option_codes.json]
 
 + Request
     + Headers

--- a/option_codes.json
+++ b/option_codes.json
@@ -1,0 +1,211 @@
+{
+   "AdapterType":{
+      "AD02":"NEMA 14-50",
+      "AD04":"European 3-Phase",
+      "AD05":"European 3-Phase, IT",
+      "AD06":"Schuko (1 phase, 230V 13A)",
+      "AD07":"Red IEC309 (3 phase 400V 16A)",
+      "ADPX2":"Type 2 Public Charging Connector",
+      "ADX8":"Blue IEC309 (1 phase 230V 32A)",
+      "CDM0":"CHAdeMO adapter not ordered with car",
+      "CDM1":"CHAdeMO adapter ordered with car"
+   },
+   "AudioUpgrade":{
+      "AU01":"Present?"
+   },
+   "Battery":{
+      "PBT85":"Performance battery type 85kWh"
+   },
+   "BatteryType":{
+      "BT85":"85kWh",
+      "BT70":"70kWh",
+      "BT60":"60kWh",
+      "BT40":"40kWh (Software Limited) "
+   },
+   "BrakeCalipers":{
+      "BC0B":"Black Brake Calipers",
+      "BC0R":"Red Brake Calipers"
+   },
+   "Charging":{
+      "SC01":"Supercharger hardware present",
+      "CH00":"Second charger not present",
+      "CH01":"Second charger present",
+      "HP00":"High power wall charger not ordered",
+      "HP01":"High power wall charger ordered with car"
+   },
+   "ColdWeatherPackage":{
+      "CW00":"Absent",
+      "CW02":"Present"
+   },
+   "CountryOfOrigin":{
+      "COUS":"United States",
+      "CODE":"Germany"
+   },
+   "DecorType":{
+      "IDCF":"Carbon Fiber",
+      "IDLW":"Lacewood",
+      "IDOM":"Obeche Matte",
+      "IDOG":"Obeche Gloss",
+      "IDPB":"Piano Black "
+   },
+   "DriverAssist":{
+      "DA01":"Present?"
+   },
+   "DriveSide":{
+      "DRLH":"Left Hand",
+      "DRRH":"Right Hand"
+   },
+   "DriveType":{
+      "DV2W":"RWD",
+      "DV4W":"AWD"
+   },
+   "Exterior":{
+      "X019":"Performance exterior",
+      "X020":"No performance exterior"
+   },
+   "ExteriorLighting":{
+      "X007":"Premium exterior lighting",
+      "X008":"Standard exterior lighting"
+   },
+   "FogLamps":{
+      "FG02":"Present?"
+   },
+   "Homelink":{
+      "X011":"Homelink present",
+      "X012":"Homelink absent"
+   },
+   "Liftgate":{
+      "X001":"Power liftgate",
+      "X002":"No power liftgate"
+   },
+   "Model":{
+      "S60":"S60",
+      "S85":"S85",
+      "P85":"P85",
+      "P85Plus":"P85+",
+      "S70D":"S70D",
+      "S85D":"S85D",
+      "P85D":"P85D",
+      "MDLX":"Model X"
+   },
+   "NappaTrim":{
+      "IX00":"Absent",
+      "IX01":"Present"
+   },
+   "Navigation":{
+      "X003":"Navigation present",
+      "X004":"No navigation present"
+   },
+   "Paint":{
+      "PA00":"Paint armor not present",
+      "PA01":"Paint armor present"
+   },
+   "PaintColor":{
+      "PBCW":"Solid White",
+      "PBSB":"Black",
+      "PMAB":"Metallic Brown",
+      "PMBL":"Obsidian Black",
+      "PMMB":"Metallic Blue",
+      "PMNG":"Steel Grey",
+      "PMSG":"Metallic Green",
+      "PMSS":"Silver",
+      "PMTG":"Metallic Dolphin Gray",
+      "PPMR":"Premium Multicoat Red",
+      "PPSB":"Deep Blue Metallic",
+      "PPSR":"Premium Signature Red",
+      "PPSW":"Pearl White",
+      "PPTI":"Titanium"
+   },
+   "ParcelShelf":{
+      "PS01":"Ordered"
+   },
+   "Performance":{
+      "PF01":"Performance model",
+      "PX00":"Not performance+ model"
+   },
+   "Powertrain":{
+      "X024":"Performance powertrain",
+      "X025":"No performance powertrain"
+   },
+   "PremiumLighting":{
+      "LP00":"Absent",
+      "LP01":"Present"
+   },
+   "Radio":{
+      "X013":"Satellite radio",
+      "X014":"Standard radio"
+   },
+   "Region":{
+      "RENA":"United States",
+      "RENC":"Canada",
+      "REEU":"Europe"
+   },
+   "RoofType":{
+      "RFBC":"Body Color",
+      "RFPO":"Panoramic",
+      "RFBK":"Black"
+   },
+   "Seating":{
+      "QRLB":"Next gen (Recaro) seat Black Leather ?",
+      "QYMB":"Black performance leather seats"
+   },
+   "SeatType":{
+      "IBMB":"Base Textile, Black",
+      "IPMB":"Leather, Black",
+      "IPMG":"Leather, Gray",
+      "IPMT":"Leather, Tan",
+      "IZZW":"Perf Leather with Grey Piping, White",
+      "QYMT":"Leather, Tan",
+      "QZMB":"Perf Leather with Piping, Black",
+      "IZMB":"Perf Leather with Piping, Black",
+      "IZMG":"Perf Leather with Piping, Gray",
+      "IZMT":"Perf Leather with Piping, Tan",
+      "ISZW":"Signature Perforated Leather, White",
+      "ISZT":"Signature Perforated Leather, Tan",
+      "ISZB":"Signature Perforated Leather, Black",
+      "TR00":"No third row seating"
+   },
+   "SecurityPackage":{
+      "SP00":"Absent",
+      "SP01":"Present"
+   },
+   "Suspension":{
+      "SU00":"No air suspension",
+      "SU01":"Air suspension"
+   },
+   "TechPackage":{
+      "TP01":"Present",
+      "TP02":"Tech package includes autopilot"
+   },
+   "TrimLevel":{
+      "TM00":"Standard Production Trim",
+      "TM02":"Signature Performance Trim"
+   },
+   "WheelType":{
+      "WT19":"Silver 19\"",
+      "WT1P":"Silver 19\"",
+      "WTX1":"Silver 19\"",
+      "WTAE":"Aero 19\"",
+      "WTAP":"Aero 19\"",
+      "WTTB":"Turbine 19\"",
+      "WTTP":"Turbine 19\"",
+      "WTTG":"Turbine 19\" Charcoal",
+      "WTGP":"Turbine 19\" Charcoal",
+      "WT21":"Silver 21\"",
+      "WT2E":"Silver 21\" Euro",
+      "WTSS":"Super 21\" Silver",
+      "WTSP":"Charcoal 21\"",
+      "WTSE":"Charcoal 21\" Euro",
+      "WTSG":"Super 21\" Gray"
+   },
+   "YachtFloor":{
+      "YF00":"Absent",
+      "YF01":"Present"
+   },
+   "Year":{
+      "MS01":"2012 Model",
+      "MS02":"2013 Model",
+      "MS03":"2014 Model",
+      "MS04":"2015 Model"
+   }
+}


### PR DESCRIPTION
I changed the parameters and URL components in the documentation that claimed to be vehicle_id fields to id fields because that is what actually works against the API. I also combined option code sets found at https://docs.google.com/document/d/1ctuUKgEwi9JlQCjLX40Yx7n1pYKRnRsO6I7RzrPd3Sk/edit# and https://github.com/jpasqua/TeslaClient into a well formatted JSON object. It is not complete, but I believe is the best compilation available.