### PR TITLE
Add token expiry status

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -19,17 +19,14 @@ module TeslaApi
 
     def expires_in=(seconds)
       @expires_in = seconds.to_f
-      puts "store expires_in #{@expires_in.to_s}"
     end
 
     def created_at=(timestamp)
       @created_at = Time.at(timestamp.to_f).to_datetime
-      puts "store created_at #{@created_at.to_s}"
     end
 
     def expired_at
       return nil unless defined?(@created_at)
-      puts "store expired_at #{(@created_at.to_time + @expires_in.to_f).to_s}"
       (@created_at.to_time + @expires_in.to_f).to_datetime
     end
 

--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -17,6 +17,27 @@ module TeslaApi
       self.class.headers "Authorization" => "Bearer #{token}"
     end
 
+    def expires_in=(seconds)
+      @expires_in = seconds.to_f
+      puts "store expires_in #{@expires_in.to_s}"
+    end
+
+    def created_at=(timestamp)
+      @created_at = Time.at(timestamp.to_f).to_datetime
+      puts "store created_at #{@created_at.to_s}"
+    end
+
+    def expired_at
+      return nil unless defined?(@created_at)
+      puts "store expired_at #{(@created_at.to_time + @expires_in.to_f).to_s}"
+      (@created_at.to_time + @expires_in.to_f).to_datetime
+    end
+
+    def expired?
+      return true unless defined?(@created_at)
+      expired_at <= DateTime.now
+    end
+
     def login!(password)
       response = self.class.post(
           "https://owner-api.teslamotors.com/oauth/token",
@@ -28,8 +49,10 @@ module TeslaApi
               "password" => password
           }
       )
-
-      self.token = response["access_token"]
+      
+      self.expires_in = response["expires_in"]
+      self.created_at = response["created_at"]
+      self.token      = response["access_token"]
     end
 
     def vehicles

--- a/spec/cassettes/client-login.yml
+++ b/spec/cassettes/client-login.yml
@@ -42,7 +42,7 @@ http_interactions:
       - '0.416152'
     body:
       encoding: UTF-8
-      string: '{"access_token":"1cba4845a8653d4b731440e9911d84304a179bd16a9ecbc9b649f2d8e0f6947e","token_type":"bearer","expires_in":7776000}'
+      string: '{"access_token":"1cba4845a8653d4b731440e9911d84304a179bd16a9ecbc9b649f2d8e0f6947e","token_type":"bearer","expires_in":7776000,"created_at":1475777133}'
     http_version: 
   recorded_at: Mon, 15 Dec 2014 03:09:22 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/tesla_api/client_spec.rb
+++ b/spec/lib/tesla_api/client_spec.rb
@@ -3,6 +3,16 @@ require 'spec_helper'
 RSpec.describe TeslaApi::Client do
   subject(:tesla_api) { TeslaApi::Client.new(ENV["TESLA_EMAIL"]) }
 
+  describe "#new client" do
+    it "has no expiry date" do
+      expect(tesla_api.expired_at).to eq(nil)
+    end
+
+    it "has a expiry status set to true" do
+      expect(tesla_api.expired?).to eq(true)
+    end
+  end
+
   describe "#token=" do
     it "sets a Bearer token" do
       tesla_api.token = Faker::Lorem.characters(32)
@@ -18,14 +28,31 @@ RSpec.describe TeslaApi::Client do
       expect(a_request(:post, "https://#{URI.parse(tesla_api.class.base_uri).host}/oauth/token")).to have_been_made.once
     end
 
-    it "obtains a Bearer token" do
+    it "set a expiry date" do
       tesla_api.login!(ENV["TESLA_PASS"])
-      expect(tesla_api.token).to match(/[a-z0-9]{32}/)
+      expect(tesla_api.expired_at).to eq(Time.at(1475777133 + 7776000).to_datetime)
+    end
+
+    it "expose expiry status" do
+      tesla_api.login!(ENV["TESLA_PASS"])
+      tesla_api.created_at = (Time.now - 1).to_i
+      expect(tesla_api.expired?).to eq(false)
+    end
+
+    it "is expired when has a 90+ days old date" do
+      tesla_api.login!(ENV["TESLA_PASS"])
+      tesla_api.created_at = (Time.now - 7776000 - 1).to_i
+      expect(tesla_api.expired?).to eq(true)
     end
 
     it "sets a Bearer token header" do
       tesla_api.login!(ENV["TESLA_PASS"])
       expect(tesla_api.class.headers).to include({"Authorization" => /Bearer [a-z0-9]{32}/})
+    end
+
+    it "obtains a Bearer token" do
+      tesla_api.login!(ENV["TESLA_PASS"])
+      expect(tesla_api.token).to match(/[a-z0-9]{32}/)
     end
   end
 


### PR DESCRIPTION
`/oauth/token` provides `expires_in: <seconds>` and `created_at: <timestamp>`
so I added a method `.expired?` in `TeslaApi::Client`.

Inspired from behavior of the [intridea/oauth2](https://github.com/intridea/oauth2/blob/master/lib/oauth2/access_token.rb) gem.

Thanks @timdorr !