### PR TITLE
Remove email attribute from Vehicle

### DIFF
--- a/lib/tesla_api/client.rb
+++ b/lib/tesla_api/client.rb
@@ -46,14 +46,14 @@ module TeslaApi
               "password" => password
           }
       )
-      
+
       self.expires_in = response["expires_in"]
       self.created_at = response["created_at"]
       self.token      = response["access_token"]
     end
 
     def vehicles
-      self.class.get("/vehicles")["response"].map { |v| Vehicle.new(self.class, email, v["id"], v) }
+      self.class.get("/vehicles")["response"].map { |v| Vehicle.new(self.class, v["id"], v) }
     end
   end
 end

--- a/lib/tesla_api/vehicle.rb
+++ b/lib/tesla_api/vehicle.rb
@@ -2,11 +2,10 @@ module TeslaApi
   class Vehicle
     include Stream
     include Autopark
-    attr_reader :api, :email, :id, :vehicle
+    attr_reader :api, :id, :vehicle
 
-    def initialize(api, email, id, vehicle)
+    def initialize(api, id, vehicle)
       @api = api
-      @email = email
       @id = id
       @vehicle = vehicle
     end


### PR DESCRIPTION
It isn't used anywhere in the `Vehicle` class, so seems extraneous. 

It is still accessible from `Vehicle#api`